### PR TITLE
chore: reorganize in preparation for setting multiple backgrounds

### DIFF
--- a/gui/src/deadliner.rs
+++ b/gui/src/deadliner.rs
@@ -434,7 +434,9 @@ fn background_edit(ui: &mut egui::Ui, bg: &mut Background) {
         }
         Background::FromDisk { location, .. } => {
             ui.horizontal(|ui| {
-                let mut is_valid = true;
+                #[derive(Clone)]
+                struct IsValid(bool);
+
                 if ui.button("Open file…").clicked() {
                     if let Some(path) = rfd::FileDialog::new().pick_file() {
                         let new_location = path.display().to_string();
@@ -443,15 +445,20 @@ fn background_edit(ui: &mut egui::Ui, bg: &mut Background) {
                         let file_ext = file_name.split(".").collect::<Vec<&str>>().pop().unwrap();
                         let supported_file_ext = ["png", "gif", "jpg", "jpeg"];
 
+                        let mut data = ui.data();
+                        let is_valid = data.get_temp_mut_or(ui.id(), IsValid(true));
+                        
                         if supported_file_ext.contains(&file_ext) {
                             *location = new_location;
-                            is_valid = true;
+
+                            *is_valid = IsValid(true);
                         } else {
-                            is_valid = false;
+                            *is_valid = IsValid(false);
                         }
                     }
                 }
 
+                let is_valid = ui.data().get_temp_mut_or(ui.id(), IsValid(true)).0;
                 if !is_valid {
                     ui.colored_label(Color32::from_rgb(255, 48, 48), "Not an Image");
                 } else if !location.is_empty() {

--- a/gui/src/update_wallpaper.rs
+++ b/gui/src/update_wallpaper.rs
@@ -1,7 +1,7 @@
 use std::fs;
 
 use crate::{
-    download_image, get_cache_dir, new_path, unwrap_or_return, BackgroundOptions, Font,
+    download_image, get_cache_dir, new_path, unwrap_or_return, Font, SanitizedBackground,
     SanitizedConf, ScreenDimensions,
 };
 use chrono::{Local, NaiveDateTime};
@@ -125,36 +125,36 @@ pub fn generate_wallpaper(deadline_str: &str, conf: &SanitizedConf) -> Result<St
 
     let mut background;
 
-    if conf.bg_type == BackgroundOptions::FromDisk {
-        background = image::open(conf.bg_location.as_ref().unwrap()).unwrap();
-    } else if conf.bg_type == BackgroundOptions::Solid {
-        let ScreenDimensions { width, height } = conf.screen_dimensions;
+    match &conf.default_bg {
+        SanitizedBackground::FromDisk(path) => {
+            background = image::open(path).unwrap();
+        }
+        SanitizedBackground::Solid { rgb, .. } => {
+            let ScreenDimensions { width, height } = conf.screen_dimensions;
 
-        let mut image = RgbImage::new(width, height);
+            let mut image = RgbImage::new(width, height);
 
-        draw_filled_rect_mut(
-            &mut image,
-            Rect::at(0, 0).of_size(width, height),
-            Rgb(conf.bg_color_arr),
-        );
+            draw_filled_rect_mut(&mut image, Rect::at(0, 0).of_size(width, height), Rgb(*rgb));
 
-        background = DynamicImage::ImageRgb8(image);
-    } else {
-        let downloaded_image = match download_image(conf.bg_url.as_ref().unwrap()) {
-            Ok(img) => img,
-            Err(_) => {
-                return Err(String::from(
-                    "Couldn't download the Image from the supplied URL!",
-                ))
-            }
-        };
+            background = DynamicImage::ImageRgb8(image);
+        }
+        SanitizedBackground::FromURL(url) => {
+            let downloaded_image = match download_image(url) {
+                Ok(img) => img,
+                Err(_) => {
+                    return Err(String::from(
+                        "Couldn't download the Image from the supplied URL!",
+                    ))
+                }
+            };
 
-        background = image::io::Reader::open(downloaded_image)
-            .unwrap()
-            .with_guessed_format()
-            .unwrap()
-            .decode()
-            .unwrap();
+            background = image::io::Reader::open(downloaded_image)
+                .unwrap()
+                .with_guessed_format()
+                .unwrap()
+                .decode()
+                .unwrap();
+        }
     }
 
     if background.width() <= text_png.size.width || background.height() <= text_png.size.height {
@@ -194,36 +194,36 @@ pub fn generate_deadline_over_wallpaper(
 
     let mut background;
 
-    if conf.bg_type == BackgroundOptions::FromDisk {
-        background = image::open(conf.bg_location.as_ref().unwrap()).unwrap();
-    } else if conf.bg_type == BackgroundOptions::Solid {
-        let ScreenDimensions { width, height } = conf.screen_dimensions;
+    match &conf.default_bg {
+        SanitizedBackground::FromDisk(path) => {
+            background = image::open(path).unwrap();
+        }
+        SanitizedBackground::Solid { rgb, .. } => {
+            let ScreenDimensions { width, height } = conf.screen_dimensions;
 
-        let mut image = RgbImage::new(width, height);
+            let mut image = RgbImage::new(width, height);
 
-        draw_filled_rect_mut(
-            &mut image,
-            Rect::at(0, 0).of_size(width, height),
-            Rgb(conf.bg_color_arr),
-        );
+            draw_filled_rect_mut(&mut image, Rect::at(0, 0).of_size(width, height), Rgb(*rgb));
 
-        background = DynamicImage::ImageRgb8(image);
-    } else {
-        let downloaded_image = match download_image(conf.bg_url.as_ref().unwrap()) {
-            Ok(img) => img,
-            Err(_) => {
-                return Err(String::from(
-                    "Couldn't download the Image from the supplied URL!",
-                ))
-            }
-        };
+            background = DynamicImage::ImageRgb8(image);
+        }
+        SanitizedBackground::FromURL(url) => {
+            let downloaded_image = match download_image(url) {
+                Ok(img) => img,
+                Err(_) => {
+                    return Err(String::from(
+                        "Couldn't download the Image from the supplied URL!",
+                    ))
+                }
+            };
 
-        background = image::io::Reader::open(downloaded_image)
-            .unwrap()
-            .with_guessed_format()
-            .unwrap()
-            .decode()
-            .unwrap();
+            background = image::io::Reader::open(downloaded_image)
+                .unwrap()
+                .with_guessed_format()
+                .unwrap()
+                .decode()
+                .unwrap();
+        }
     }
 
     if background.width() <= text_png.size.width || background.height() <= text_png.size.height {


### PR DESCRIPTION
Hey there, I was just going to experiment with some UI update for the image countdown, and I ran into some code that I felt could benefit from a little bit of re-organization to make it easier to work with the backgrounds.

It essentially just moves all the separate variables used to track the background selection into an enum.

This is just my personal preference on organization, so totally fine if you don't like it!